### PR TITLE
blocksvar: use uid union syntax in example

### DIFF
--- a/content/blocksvars/6.md
+++ b/content/blocksvars/6.md
@@ -43,12 +43,12 @@ of those actors list the movies they have made with either director.
   actors(func: uid(A_PJ)) @filter(uid(A_MS)) @cascade {
     actor: name@en
     actor.film {
-      performance.film @filter (uid(F_PJ) OR uid(F_MS)) {
+      performance.film @filter (uid(F_PJ, F_MS)) {
       	name@en
       }
     }
   }
 }
 ```  
-The syntax `uid(F_PJ,F_MS)` means the UIDs in both `F_PJ` and `F_MS` and is equivalent to `uid(F_PJ) OR uid(F_MS)`.
+The syntax `uid(F_PJ, F_MS)` means the UIDs in both `F_PJ` and `F_MS` and is equivalent to `uid(F_PJ) OR uid(F_MS)`.
 {{% /expandable %}}


### PR DESCRIPTION
The note at the bottom of the page refers to a `uid(F_PJ,F_MS)` syntax which is not used in the example. This change explains a thing that exists, rather than requiring the reader to understand that the thing could exist.

Please take a look.