### PR TITLE
search: get the user to add the exact index

### DIFF
--- a/content/search/4.md
+++ b/content/search/4.md
@@ -7,5 +7,6 @@ weight = 4
 +++
 
 With the `exact` index inequalities on strings can be used in filters.
+Try the query after adding the `exact` index [to the string indexes](/search/1/).
 
 The `hash` index allows fast filtering for `eq` on strings.


### PR DESCRIPTION
The `exact` index was not built in p1 of search, so the query on this page fails. Rather than adding `exact` to p1, get the user to do it.

Please take a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/28)
<!-- Reviewable:end -->
