### PR TITLE
Fix memory_mb flag

### DIFF
--- a/content/intro/2.md
+++ b/content/intro/2.md
@@ -36,7 +36,7 @@ mkdir -p ~/dgraph
 docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph dgraph/dgraph dgraph zero
 
 # In another terminal, now run dgraph
-docker exec -it dgraph dgraph server --memory_mb 2048 --zero localhost:5080
+docker exec -it dgraph dgraph server --lru_mb 2048 --zero localhost:5080
 
 # And in another, run ratel (Dgraph UI)
 docker exec -it dgraph dgraph-ratel


### PR DESCRIPTION
When I tried the tutorial, `--memory_mb` option does not exist, but `--lru_mb` does.
Please take a look.