### PR TITLE
Corrected spelling of boss in query description

### DIFF
--- a/content/schema/5.md
+++ b/content/schema/5.md
@@ -20,4 +20,4 @@ There are two choices to query in both directions
 Run the schema mutation and Dgraph will compute all the reverse edges.
  The reverse edge of `an_edge` is `~an_edge`.
 
-In terms of data modeling, some reverse edges always make sense, such as `friend`. Others, such as `boos_of`, are sometimes, but not always bidirectional.
+In terms of data modeling, some reverse edges always make sense, such as `friend`. Others, such as `boss_of`, are sometimes, but not always bidirectional.


### PR DESCRIPTION
Small spelling error in left-hand side description, does not break query.