### PR TITLE
Fix typo

### DIFF
--- a/content/basic/3.md
+++ b/content/basic/3.md
@@ -28,7 +28,7 @@ Here are the types you can use to store values in Dgraph.
 |  `float`    | double precision floating point number   |
 |  `string`   | string  |
 |  `bool`     | boolean    |
-|  `id`       | ID's stored as strings  |
+|  `id`       | identifiers stored as strings  |
 |  `dateTime` | RFC3339 time format with optional timezone eg: 2006-01-02T15:04:05.999999999+10:00 or 2006-01-02T15:04:05.999999999    |
 |  `geo`      | geometries stored using [go-geom](https://github.com/twpayne/go-geom)    |
 


### PR DESCRIPTION
ID's is not a valid plural form of "id"