### PR TITLE
v1.1 changes and other minor changes

### DIFF
--- a/content/basic/1.md
+++ b/content/basic/1.md
@@ -1,7 +1,7 @@
 +++
 date = "2017-04-26T22:36:18+10:00"
 next = "/basic/2"
-prev = "/intro/6"
+prev = "/intro/8"
 title = "Hello World"
 weight = 1
 +++

--- a/content/basic/17.md
+++ b/content/basic/17.md
@@ -27,7 +27,7 @@ For JSON mutation with Facets see: https://docs.dgraph.io/mutations/#facets
 Run this mutation on you terminal, before running the query:
 {{% expandable %}}
 ```
-curl localhost:8080/mutate -H "X-Dgraph-CommitNow: true" -XPOST -d $'
+curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -XPOST -d $'
 {
   set {
 

--- a/content/moredata/1.txt
+++ b/content/moredata/1.txt
@@ -18,7 +18,7 @@ type Genre {
 
 # Define Directives and index
 
-director.film: uid @reverse .
-genre: uid @reverse .
+director.film: [uid] @reverse .
+genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(term) @lang .

--- a/content/schema/1.md
+++ b/content/schema/1.md
@@ -1,7 +1,7 @@
 +++
 date = "2017-04-26T21:53:48+10:00"
 next = "/schema/2"
-prev = "/basic/17"
+prev = "/basic/18"
 title = "Adding schema - mutating schema"
 weight = 1
 endpoint = "/alter"

--- a/content/schema/1.txt
+++ b/content/schema/1.txt
@@ -13,4 +13,4 @@ type Company {
 # Define Directives and index
 
 industry: string @index(term) .
-boss_of: uid .
+boss_of: [uid] .

--- a/content/schema/5.txt
+++ b/content/schema/5.txt
@@ -1,1 +1,1 @@
-boss_of: uid @reverse .
+boss_of: [uid] @reverse .

--- a/content/search/7.md
+++ b/content/search/7.md
@@ -1,7 +1,7 @@
 +++
 date = "2017-05-15T15:32:26+10:00"
 next = "/"
-prev = "/search/5"
+prev = "/search/6"
 title = "Geo queries : Near"
 weight = 7
 +++

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -9,7 +9,7 @@ BASE_URL_ENV = 'TOUR_BASE_URL'
 
 def exec(*argv):
     print("$>"," ".join(argv))
-    res = sp.run(argv, capture_output=True)
+    res = sp.run(argv, stdout=sp.PIPE, stderr=sp.PIPE)
     if not res.returncode == 0:
         print('Error running', argv)
         print('StdOut:\n', res.stdout)

--- a/themes/hugo-tutorials/static/css/theme.css
+++ b/themes/hugo-tutorials/static/css/theme.css
@@ -181,7 +181,7 @@ html body {
   margin-bottom: 1rem;
 }
 .expandable.expanded .expandable-content {
-  max-height: 2300px;
+  max-height: 3000px;
 }
 .expandable .expandable-content {
   max-height: 0;


### PR DESCRIPTION
- changed uid to [uid]. #73 
- increased the maximum height of %expandable% block - resolving the partial visibility of query in /intro/4 #71 
- fixed previous page reference in markdowns
- replaced capture_output with the native implementation for support of python<=3.7