### PR TITLE
[Intro 4] Properly set type for "Perro" dog

### DIFF
--- a/content/intro/4.txt
+++ b/content/intro/4.txt
@@ -60,6 +60,6 @@
     _:goldie <dgraph.type> "Animal" .
 
     _:perro <name> "Perro" .
-    _:goldie <dgraph.type> "Animal" .
+    _:perro <dgraph.type> "Animal" .
   }
 }


### PR DESCRIPTION
The tour has a typo on the `intro/4` chapter. It's setting the type for "Goldie" twice, instead of setting it for "Perro".

This PR should fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/95)
<!-- Reviewable:end -->
