### PR TITLE
[Schema 6] Make `boss_of` and `works_for` edges reversed

### DIFF
--- a/content/schema/1.txt
+++ b/content/schema/1.txt
@@ -15,6 +15,6 @@ type Company {
 # Define Directives and index
 
 industry: string @index(term) .
-boss_of: [uid] .
+boss_of: [uid] @reverse .
 name: string @index(exact, term) .
-works_for: [uid] .
+works_for: [uid] @reverse .


### PR DESCRIPTION
The query in Schema 6 fails because the `works_for` edge is not `@reverse` when defined at Schema 1. 

This PR fixes the issue and makes the `boss_of` edge reverse too. An alternative approach is modifying the schema in Schema 6 to set these fields as `@reverse`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/99)
<!-- Reviewable:end -->
