### PR TITLE
Fix Markdown rendering in shortcode notices.

### DIFF
--- a/themes/hugo-tutorials/layouts/shortcodes/expandable.html
+++ b/themes/hugo-tutorials/layouts/shortcodes/expandable.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expandable">
   <a data-action="toggle-expandable" href="#expand">
     <i class="fa fa-caret-down"></i> Show answer

--- a/themes/hugo-tutorials/layouts/shortcodes/expandable.html
+++ b/themes/hugo-tutorials/layouts/shortcodes/expandable.html
@@ -1,9 +1,8 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expandable">
   <a data-action="toggle-expandable" href="#expand">
     <i class="fa fa-caret-down"></i> Show answer
   </a>
   <div class="expandable-content">
-    {{ .Inner }}
+    {{ .Inner | markdownify }}
   </div>
 </div>

--- a/themes/hugo-tutorials/layouts/shortcodes/notice.html
+++ b/themes/hugo-tutorials/layouts/shortcodes/notice.html
@@ -1,6 +1,5 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
 {{ $type := .Get 0}}
 
 <div class="notices {{ $type }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
-  <span class="type">{{ humanize $type }}</span> {{ .Inner }}
+  <span class="type">{{ humanize $type }}</span> {{ .Inner | markdownify }}
 </div>

--- a/themes/hugo-tutorials/layouts/shortcodes/notice.html
+++ b/themes/hugo-tutorials/layouts/shortcodes/notice.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 {{ $type := .Get 0}}
 
 <div class="notices {{ $type }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>


### PR DESCRIPTION
This PR resolves #100 and parsing links inside shortcodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/101)
<!-- Reviewable:end -->
