### PR TITLE
Update config.toml intro description

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,7 +37,7 @@ theme="hugo-tutorials"
 
 [params]
   [params.menudesc]
-    intro = "In this lesson you'll learn how to set up and run Dgraph for the tutorial and learn about graph databases"
+    intro = "In this lesson you'll learn how to set up and run Dgraph for the tutorial and learn about graph databases."
     basic = "Here you'll learn the basics of how to query graph data from Dgraph and how to use and interpret the results."
     schema = "This lesson shows you how schemas work inside Dgraph, and how to add, update and delete data (in Dgraph, that's mutate data)."
     moredata = "Now that you've got some Dgraph experience, this lesson shows you how to use dgraph live loader to load large datasets.  You'll need this bigger dataset for the remaining sections of the tutorial."


### PR DESCRIPTION
no related issue

Adding a period to the end of the intro description. I just happened to spot this when I started going through the tutorial again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/108)
<!-- Reviewable:end -->
