### PR TITLE
Fix schema error for missing attribute definition.

### DIFF
--- a/content/schema/1.txt
+++ b/content/schema/1.txt
@@ -18,3 +18,4 @@ industry: string @index(term) .
 boss_of: [uid] .
 name: string @index(exact, term) .
 works_for: [uid] .
+work_here: [uid] .


### PR DESCRIPTION
Missing `work_here` definition.
The server responses:
```
APIError: Schema does not contain a matching predicate for field work_here in type Company
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/114)
<!-- Reviewable:end -->
