### PR TITLE
Add missing predicate actor.film in moredata/2 (issue 122)

### DIFF
--- a/content/moredata/2.txt
+++ b/content/moredata/2.txt
@@ -1,27 +1,24 @@
 # Define Types
 
 type Person {
-    name: string
-    director.film: [Movie]
-    actor.film: [Performance]
+    name
+    director.film
+    actor.film
 }
 
 type Movie {
-    name: string
-    initial_release_date: string
-    genre: [Genre]
-    starring: [Performance]
+    name
+    initial_release_date
+    genre
+    starring
 }
 
 type Genre {
-    name: string
+    name
 }
 
 type Performance {
-    performance.film: [Movie]
-    performance.character_note: string
-    performance.character: [Person]
-    performance.actor: [Person]
-    performance.special_performance_type: [Special_performance_type]
-    type: [Generic]
+    performance.film
+    performance.character
+    performance.actor
 }

--- a/content/moredata/2.txt
+++ b/content/moredata/2.txt
@@ -3,6 +3,7 @@
 type Person {
     name: string
     director.film: [Movie]
+    actor.film: [Performance]
 }
 
 type Movie {


### PR DESCRIPTION
More explicit is better.
Add the predicate `actor.film` in schema for better visualization of data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/124)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Tour Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-tour-d3bc2d0a98-44981.surge.sh)
<!-- Dgraph:end -->