### PR TITLE
basic cascade description update to match example in editable text

### DIFF
--- a/content/basic/14.md
+++ b/content/basic/14.md
@@ -42,4 +42,4 @@ With the `@cascade` directive, friends of Michael that don't own a pet are not i
 }
 ```
 
-More details about Cascade you can find in our Docs: https://dgraph.io/docs/query-language/#cascade-directive
+You can read more about `@cascade` directive in our documentation site: https://dgraph.io/docs/query-language/#cascade-directive

--- a/content/basic/14.md
+++ b/content/basic/14.md
@@ -12,40 +12,34 @@ edges in the query.
 Another use is to remove nodes where a filter inside a block returns
 no results.
 
-In the query below, Dgraph returns all Michael's friends,
-and only the friends of friends who are over 27.
+In the query below, Dgraph returns all Michael's friends, whether or not they own a pet.
 
 ```
 {
-  michael_friends(func: allofterms(name, "Michael")) {
+  michael_friends_with_pets(func: allofterms(name, "Michael")) @cascade {
     name
     age
     friend {
       name@.
-      friend @filter(ge(age, 27)) {
-        name@.
-        age
-      }
+      owns_pet
     }
   }
 }
 ```
 
-With the `@cascade` directive, friends of Michael that don't have friends who 
-are over 27 are not included in the result.
+With the `@cascade` directive, friends of Michael that don't own a pet are not included in the result.
 
 ```
 {
-  michael_friends(func: allofterms(name, "Michael")) @cascade {
+  michael_friends_with_pets(func: allofterms(name, "Michael")) {
     name
     age
     friend {
       name@.
-      friend @filter(ge(age, 27)) {
-        name@.
-        age
-      }
+      owns_pet
     }
   }
 }
 ```
+
+More details about Cascade you can find in our Docs: https://dgraph.io/docs/query-language/#cascade-directive

--- a/content/basic/14.md
+++ b/content/basic/14.md
@@ -16,7 +16,7 @@ In the query below, Dgraph returns all Michael's friends, whether or not they ow
 
 ```
 {
-  michael_friends_with_pets(func: allofterms(name, "Michael")) @cascade {
+  michael_friends_with_pets(func: allofterms(name, "Michael"))  {
     name
     age
     friend {
@@ -31,7 +31,7 @@ With the `@cascade` directive, friends of Michael that don't own a pet are not i
 
 ```
 {
-  michael_friends_with_pets(func: allofterms(name, "Michael")) {
+  michael_friends_with_pets(func: allofterms(name, "Michael")) @cascade {
     name
     age
     friend {


### PR DESCRIPTION
There were two examples given.  The friends of friends was more complex for exposure, and the existing owns_pet is simple and easily illustrates the cascade concept.  

Also, as there is so much more you can do with this, such as using this directive along in subquery, so put a link at the bottom for learners that are curious.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/137)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Tour Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-tour-0ecaddf340-51663.surge.sh)
<!-- Dgraph:end -->