### PR TITLE
Updating the build script

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -57,12 +57,12 @@ def compareVersions(a, b):
 
 
 def getReleases():
-    gitBranches = exec("git", "branch")
+    gitBranches = exec("git", "branch", "-a")
     branches = gitBranches.stdout.decode('utf8')
     branches = branches.split('\n')
     res = []
     for b in branches:
-        match = re.compile(r"[ *]+dgraph-([0-9.]+)").match(b)
+        match = re.compile(r"[ *]+remotes/origin/dgraph-([0-9.]+)").match(b)
         if match:
             res.append(match.group(1))
     print('Found release versions', res)


### PR DESCRIPTION
Currently, the python build script makes an assumption that you have the release versions `dgraph-X.Y.Z` on your local machine. On a new machine, you would get the error below:

```python
$> git branch
Found release versions []
Order on the webpage:  ['master']
$> rm -rf public
$> mkdir public
Traceback (most recent call last):
  File "scripts/build.py", line 124, in <module>
    main()
  File "scripts/build.py", line 115, in main
    buildAll(releases)
  File "scripts/build.py", line 87, in buildAll
    latestRelease = releases[1]
IndexError: list index out of range
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/167)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Tour Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-tour-f256fd9ff2-67774.surge.sh)
<!-- Dgraph:end -->