### PR TITLE
fix schema in tour (load more data)

### DIFF
--- a/content/moredata/1.txt
+++ b/content/moredata/1.txt
@@ -1,6 +1,7 @@
 # Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/dgraph-1.2.1/moredata/1.txt
+++ b/published/dgraph-1.2.1/moredata/1.txt
@@ -1,6 +1,7 @@
 # Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/dgraph-1.2.1/moredata/1/index.html
+++ b/published/dgraph-1.2.1/moredata/1/index.html
@@ -657,6 +657,7 @@ functions require particular indexes.</p>
 <div class="runnable" data-initial="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -670,6 +671,7 @@ type: [uid] .
 " data-current="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -708,6 +710,7 @@ type: [uid] .
         <textarea class="query-content-editable"># Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/dgraph-20.03.0/moredata/1.txt
+++ b/published/dgraph-20.03.0/moredata/1.txt
@@ -1,6 +1,7 @@
 # Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/dgraph-20.03.0/moredata/1/index.html
+++ b/published/dgraph-20.03.0/moredata/1/index.html
@@ -291,6 +291,7 @@ functions require particular indexes.</p>
 <div class="runnable" data-initial="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -304,6 +305,7 @@ type: [uid] .
 " data-current="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -340,6 +342,7 @@ type: [uid] .
         <textarea class="query-content-editable"># Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/master/moredata/1.txt
+++ b/published/master/moredata/1.txt
@@ -1,6 +1,7 @@
 # Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/master/moredata/1/index.html
+++ b/published/master/moredata/1/index.html
@@ -316,6 +316,7 @@ functions require particular indexes.</p>
 <div class="runnable" data-initial="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -354,6 +355,7 @@ type Performance {
 " data-current="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -415,6 +417,7 @@ type Performance {
         <textarea class="query-content-editable"># Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/moredata/1.txt
+++ b/published/moredata/1.txt
@@ -1,6 +1,7 @@
 # Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .

--- a/published/moredata/1/index.html
+++ b/published/moredata/1/index.html
@@ -291,6 +291,7 @@ functions require particular indexes.</p>
 <div class="runnable" data-initial="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -304,6 +305,7 @@ type: [uid] .
 " data-current="# Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .
@@ -340,6 +342,7 @@ type: [uid] .
         <textarea class="query-content-editable"># Define Directives and index
 
 director.film: [uid] @reverse .
+actor.film: [uid] @count .
 genre: [uid] @reverse .
 initial_release_date: dateTime @index(year) .
 name: string @index(exact, term) @lang .


### PR DESCRIPTION
There was some mistake in copying the schema from [here](https://github.com/dgraph-io/benchmarks/blob/master/data/1million.schema). It results into `Could not alter schema: Schema does not contain a matching predicate for field actor.film in type Person` error.

This commit fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/tutorial/177)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Tour Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-tour-c2608d7e2c-71756.surge.sh)
<!-- Dgraph:end -->