### PR TITLE
Remove RankSci tracking script from footer

### DIFF
--- a/themes/hugo-tutorials/layouts/partials/footer.html
+++ b/themes/hugo-tutorials/layouts/partials/footer.html
@@ -9,7 +9,7 @@
 <script src='{{ relURL "/js/build/dgraph-tour.js" }}?{{ now.Format "2006-01-02T150405" }}'></script>
 <script src='{{ relURL "/js/basic.js" }}?{{ md5 (readFile "themes/hugo-tutorials/static/js/basic.js") }}'></script>
 <script src="//unpkg.com/@dgraph-io/community"></script>
-<script src='https://cdn.ranksci.com/dgraph-411505.min.js' type='text/javascript'></script>
+
 <link href='{{ relURL "/css/runnable.css" }}?{{ md5 (readFile "themes/hugo-tutorials/static/css/runnable.css") }}' rel="stylesheet"/>
 
 </html>


### PR DESCRIPTION
## Summary
- Removes the external RankSci analytics script (`cdn.ranksci.com/dgraph-411505.min.js`) from the site footer
- Reduces page load time by eliminating an unnecessary third-party request
- No functional impact on the tutorial site

## Test plan
- [x] Verify the tour site loads correctly without the script
- [x] Confirm no console errors related to the removed script
- [ ] Check that no other functionality depended on RankSci